### PR TITLE
Adds publish-package.yml workflow to publish a new package 

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,14 +1,11 @@
 name: CI
 
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the master branch
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-  schedule:
-    - cron:  '0 0 * * 1'
+  # Trigger the workflow on release,
+  # but only when published
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -17,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7']
 
     steps:
     - uses: actions/checkout@v2
@@ -47,3 +44,10 @@ jobs:
     - name: Install the package locally
       run: |
         make install
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      if: github.event_name == 'release'
+      run: |
+        make release

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,6 +7,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron:  '0 0 * * 1'
   # Trigger the workflow on release,
   # but only when published
   release:
@@ -56,4 +58,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       if: github.event_name == 'release'
       run: |
-        make test-release
+        make release

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,8 +7,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  schedule:
-    - cron:  '0 0 * * 1'
   # Trigger the workflow on release,
   # but only when published
   release:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,4 +58,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       if: github.event_name == 'release'
       run: |
-        make release
+        make test-release


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
Adds publish-package.yml workflow to publish a new package. A matrix build of GitHub Actions simultaneously tries to upload the package. When the first matrix job successfully uploads the package, the successive matrix job fails to upload the package because pypi.org returns 400 Bad request due to "File already exists". We define another workflow that publishes a new package in single matrix build.